### PR TITLE
Output, input change in big.model.FElasso

### DIFF
--- a/R/big_modelFElasso.R
+++ b/R/big_modelFElasso.R
@@ -6,6 +6,7 @@
 #' to perform such project on many models using groups
 #'
 #' @param X A big.matrix object
+#' @param df_corr A list of transformation applied during convert.character
 #' @param yvar Name of the explained variable in \code{X}
 #' @param labelvar Names of variables that should be excluded from
 #' the set of covariates
@@ -23,13 +24,13 @@
 #' (\code{FALSE}) or variables labels (\code{TRUE}) in the regressions. If \code{TRUE},
 #' \code{import_label()} is used to upload data from the internet. It will fail if no
 #' internet connection is available.
-#' @return A list of two elements: \code{results} and \code{indices}.
+#' @return A list of three elements: \code{results}, \code{indices} and \code{group}.
 #' \code{results} returns a series of linear model fitted with selected features. If \code{groupingvar} is
 #' not \code{NULL}, a nested dataframe is returned with linear regressions stored by
 #' groups. \code{indices} returns the lines that have been used to estimate the model stored in
-#' \code{results}.
+#' \code{results}. \code{group} returns groups that have been estimated.
 
-big.model.FElasso <- function(X, yvar = "incidence",
+big.model.FElasso <- function(X,df_corr=NULL, yvar = "incidence",
                               labelvar = c("cancer","age", "Country_Transco", "year", "area.x","area.y"),
                               groupingvar = NULL, crossvalidation = T,
                               nfolds = 10, ncores = 1,
@@ -69,7 +70,11 @@ big.model.FElasso <- function(X, yvar = "incidence",
                              list(results = label_variables(big.FE.lasso(bigmemory::deepcopy(X, rows = i), yvar = "incidence",
                                                           labelvar = c(labelvar, groupingvar),crossvalidation,
                                                           nfolds, ncores, returnplot = returnplot)),
-                                  indices = i
+                                  indices = i,
+                                  group   = sapply(1:length(X[i[1],groupingvar]), function(ngr) plyr::mapvalues(X[i[1],groupingvar][ngr],
+                                                                                                from=df_corr[[names(X[i[1],groupingvar][ngr])]]$code, 
+                                                                                                to=as.vector(df_corr[[names(X[i[1],groupingvar][ngr])]]$value),
+                                                warn_missing = FALSE))
                              )
                            )
                          }
@@ -84,7 +89,11 @@ big.model.FElasso <- function(X, yvar = "incidence",
                              list(results = big.FE.lasso(bigmemory::deepcopy(X, rows = i), yvar = "incidence",
                                           labelvar = c(labelvar, groupingvar),crossvalidation,
                                           nfolds, ncores, returnplot = returnplot),
-                                  indices = i
+                                  indices = i,
+                                  group   = sapply(1:length(X[i[1],groupingvar]), function(ngr) plyr::mapvalues(X[i[1],groupingvar][ngr],
+                                                                                                from=df_corr[[names(X[i[1],groupingvar][ngr])]]$code, 
+                                                                                                to=as.vector(df_corr[[names(X[i[1],groupingvar][ngr])]]$value),
+                                                warn_missing = FALSE))
                              )
                            )
                          }
@@ -106,7 +115,11 @@ big.model.FElasso <- function(X, yvar = "incidence",
                            list(results = label_variables(big.FE.lasso(bigmemory::deepcopy(X, rows = i), yvar = "incidence",
                                         labelvar = c(labelvar, groupingvar),crossvalidation,
                                         nfolds, ncores = 1, returnplot = returnplot)),
-                                indices = i
+                                indices = i,
+                                group   = sapply(1:length(X[i[1],groupingvar]), function(ngr) plyr::mapvalues(X[i[1],groupingvar][ngr],
+                                                                                              from=df_corr[[names(X[i[1],groupingvar][ngr])]]$code, 
+                                                                                              to=as.vector(df_corr[[names(X[i[1],groupingvar][ngr])]]$value),
+                                                warn_missing = FALSE))                                
                            )
                          )
                        }
@@ -121,7 +134,11 @@ big.model.FElasso <- function(X, yvar = "incidence",
                              list(results = big.FE.lasso(bigmemory::deepcopy(X, rows = i), yvar = "incidence",
                                           labelvar = c(labelvar, groupingvar),crossvalidation,
                                           nfolds, ncores = 1, returnplot = returnplot),
-                                  indices = i
+                                  indices = i,
+                                  group   = sapply(1:length(X[i[1],groupingvar]), function(ngr) plyr::mapvalues(X[i[1],groupingvar][ngr],
+                                                                                                from=df_corr[[names(X[i[1],groupingvar][ngr])]]$code, 
+                                                                                                to=as.vector(df_corr[[names(X[i[1],groupingvar][ngr])]]$value),
+                                                warn_missing = FALSE))
                              )
                            )
                          }


### PR DESCRIPTION
The third output 'Group' helps users to know which group has been estimated.
Adding of "df_corr" in inputs. "df_corr" corresponds to the function convert.character output. It allows to find the correspondences of the numeric recoded character / factor variables during creation of pointer or  data in input of linear regression model.